### PR TITLE
Auto-Close Issue & Assign PR Author on Merge

### DIFF
--- a/.github/workflows/assign-pr-author-on-merge.yml
+++ b/.github/workflows/assign-pr-author-on-merge.yml
@@ -1,0 +1,33 @@
+name: Assign PR author on merge
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+
+    steps:
+      - name: Assign PR to its author
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+
+            // Get the PR author's username
+            const author = pr.user.login;
+
+            // Assign PR to the author
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              assignees: [author],
+            });
+
+            console.log(`PR #${pr.number} assigned to @${author}`);

--- a/.github/workflows/auto-close-mentioned-issues.yml
+++ b/.github/workflows/auto-close-mentioned-issues.yml
@@ -1,0 +1,57 @@
+name: Auto-close issues mentioned in merged PR
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  auto-close-issues:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+
+    steps:
+      - name: Auto-close referenced issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+
+            // Combine PR title and body
+            const text = `${pr.title}\n${pr.body || ""}`;
+
+            // Match issue references like #12, #45
+            const issueNumbers = [...text.matchAll(/#(\d+)/g)]
+              .map(match => match[1]);
+
+            if (issueNumbers.length === 0) {
+              console.log("No referenced issues found.");
+              return;
+            }
+
+            for (const issueNumber of issueNumbers) {
+              try {
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  state: "closed",
+                });
+
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  body: `Closed automatically via merged PR #${pr.number}.`,
+                });
+
+                console.log(`Closed issue #${issueNumber}`);
+              } catch (error) {
+                console.log(
+                  `Failed to close issue #${issueNumber}: ${error.message}`
+                );
+              }
+            }


### PR DESCRIPTION
✅ Automatically close the linked issue when a PR is merged
👤 Assign the issue to the author of the merged PR
🔗 Works when PRs reference issues using keywords 

fix #134 @jyotiiX 